### PR TITLE
Check that object is not a Date object before building connect variables

### DIFF
--- a/src/buildVariables.ts
+++ b/src/buildVariables.ts
@@ -342,7 +342,7 @@ const buildCreateVariables = (introspectionResults: IntrospectionResult) => (
           data = data.map((id: string) => ({ id }))
         }
 
-        let isObject = data.some((entry: any) => typeof entry === 'object')
+        let isObject = data.some((entry: any) => isObject(entry) && !isDate(entry))
 
         if (isObject) {
           data = data.map((entry: any) => Object.keys(entry)

--- a/src/buildVariables.ts
+++ b/src/buildVariables.ts
@@ -8,6 +8,7 @@ import {
   DELETE
 } from 'react-admin';
 import isObject from 'lodash/isObject';
+import isDate from 'lodash/isDate';
 
 import getFinalType from './utils/getFinalType';
 import { computeFieldsToAddRemoveUpdate } from './utils/computeAddRemoveUpdate';
@@ -258,7 +259,8 @@ const buildUpdateVariables = (introspectionResults: IntrospectionResult) => (
         }
       };
     }
-    if (isObject(data)) {
+
+    if (isObject(data) && !isDate(data)) {
 
       const fieldsToUpdate = buildReferenceField({
         inputArg: data,
@@ -394,7 +396,7 @@ const buildCreateVariables = (introspectionResults: IntrospectionResult) => (
         };
       }
 
-      if (isObject(data)) {
+      if (isObject(data) && !isDate(data)) {
         const fieldsToConnect = buildReferenceField({
           inputArg: data,
           introspectionResults,


### PR DESCRIPTION
Using DateTimeInput in react-admin cause the input data to be a Date object. Without additional checks for this, it was interpreted as an object that needed connect. This failed, and the operation as a whole failed.