### PR TITLE
Change variable isObject to entryIsObject to avoid name collision

### DIFF
--- a/src/buildVariables.ts
+++ b/src/buildVariables.ts
@@ -342,9 +342,9 @@ const buildCreateVariables = (introspectionResults: IntrospectionResult) => (
           data = data.map((id: string) => ({ id }))
         }
 
-        let isObject = data.some((entry: any) => isObject(entry) && !isDate(entry))
+        let entryIsObject = data.some((entry: any) => isObject(entry) && !isDate(entry))
 
-        if (isObject) {
+        if (entryIsObject) {
           data = data.map((entry: any) => Object.keys(entry)
             .reduce((obj: any, key: any) => {
               if (key === 'id') {


### PR DESCRIPTION
When adding the isDate check to the array contents, I inadvertently created a name collision. Supposedly that was why the old code (using typeof instead of isObject) was like it was. Changing the name of the result variable instead seems like the better fix though.

This fix seems to be necessary to be able to have arrays at all. Sorry for the mess up.