### PR TITLE
Resolve DateTime default value Scalar makes update/create mutations crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unly/ra-data-graphql-prisma",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A react-admin data provider for Prisma Server",
   "scripts": {
     "start": "cross-env-shell 'concurrently -p '{name}' -n 'lint,build,test' -c 'gray.bgWhite,yellow.bgBlue,green.bgWhite' \"yarn lint\" \"yarn build\" \"yarn test\"'",

--- a/src/buildVariables.ts
+++ b/src/buildVariables.ts
@@ -351,6 +351,12 @@ const buildUpdateVariables = (introspectionResults: IntrospectionResult) => (
       if (field) {
         // Rest should be put in data object
 
+        // ra recently added a fix on `DateInput` which send an empty string as default value instead of a null which makes update and edit mutations crash.
+        // this line should fix the issue for DateTime Scalar. We basically force a null value when there is an non desired `""`
+        if ((field.type as IntrospectionNamedTypeRef).name === 'DateTime') {
+          value = value === "" ? null : value
+        }
+
         return {
           ...acc,
           data: {
@@ -493,6 +499,13 @@ const buildCreateVariables = (introspectionResults: IntrospectionResult) => (
 
       if (field) {
         // Rest should be put in data object
+
+        // ra recently added a fix on `DateInput` which send an empty string as default value instead of a null which makes update and edit mutations crash.
+        // this line should fix the issue for DateTime Scalar. We basically force a null value when there is an non desired `""`
+        if ((field.type as IntrospectionNamedTypeRef).name === 'DateTime') {
+          data = data === "" ? null : data
+        }
+
         return {
           ...acc,
           data: {


### PR DESCRIPTION
Since [lasts ra updates](https://github.com/marmelab/react-admin/pull/6199), DateInput got a new behavior or more precisely [a fix]()

It makes DateTime Scalar update/create mutations crash.

So here is a quite rough but simple fix to be sure that DateTime value is `null` instead of `""`